### PR TITLE
Adding the sitemap generation to github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,4 @@
 name: CodeWith
+url: "https://codewith.org.uk" # the base hostname & protocol for your site
+plugins:
+  - jekyll-sitemap


### PR DESCRIPTION
Allows github pages to generate a sitemap, this may work or it may not. 

This is due to Github pages running jekyll in safe mode but did have some exclusions though I can't find any information either way 

The only way to find out is to deploy it and see if it's generated as far as I can tell