### PR TITLE
Retain OpenDyslexic settings between page refreshes

### DIFF
--- a/js/change-font.js
+++ b/js/change-font.js
@@ -1,7 +1,19 @@
 "use strict"
 
-$(function() {
+$(function () {
+    $(document).ready(function () {
+        if (localStorage.getItem("CodeWithOpenDyslexic") === "1") {
+            $('body').toggleClass('open-dyslexic');
+        }
+    });
+
     $('#change-font').click(function () {
+        if (localStorage.getItem("CodeWithOpenDyslexic") === "1") {
+            localStorage.setItem("CodeWithOpenDyslexic", 0);
+        } else {
+            localStorage.setItem("CodeWithOpenDyslexic", 1);
+        }
+
         $('body').toggleClass('open-dyslexic');
     });
 })


### PR DESCRIPTION
I noticed that the OpenDyslexic button didn't retain the settings between page changes and refreshes. Local storage was chosen because it will be retained between sessions. 