### PR TITLE
Fixes an issue where the sidebar would reopen on scroll on Apple Devices

### DIFF
--- a/js/check-width.js
+++ b/js/check-width.js
@@ -4,15 +4,20 @@ $(function () {
     var $window = $(window);
     var $pane = $('#main-container');
 
+    // Store the window width
+    var windowWidth = $window.width();
+
     function checkWidth() {
-        var windowsize = $window.width();
-        if (windowsize <= 768) {
-            if ($pane.hasClass('toggled')) {
-                $pane.toggleClass('toggled');
+        if ($(window).width() != windowWidth) {
+            var windowsize = $window.width();
+            if (windowsize <= 768) {
+                if ($pane.hasClass('toggled')) {
+                    $pane.toggleClass('toggled');
+                }
             }
-        }
-        else if (!$pane.hasClass('toggled')) {
-            $pane.addClass('toggled');
+            else if (!$pane.hasClass('toggled')) {
+                $pane.addClass('toggled');
+            }
         }
     }
 


### PR DESCRIPTION
This was caused by the window.resize event being fired on scroll on IPad browsers. 

To test this from your PC to an IPad you need to set the --host flag in the command line

See here

https://zarino.co.uk/post/jekyll-local-network/