### PR TITLE
Removing debug code from the fix that was released for the IPad sidebar bug

### DIFF
--- a/js/check-width.js
+++ b/js/check-width.js
@@ -13,7 +13,6 @@ $(function () {
                 checkWidthToggleClass();
             }
         } else {
-            console.log("CheckWidthFalse")
             checkWidthToggleClass();
         }
     }


### PR DESCRIPTION
Not really a major issue, just cleans up the console a bit for further debugging whenever we need it