### PR TITLE
Fix Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,9 @@ aws_lambda/
 docker/
 .gitignore
 README.md
+.idea/
+.vscode/
+.jekyll-metadata
+.bundle/
+vendor/
+.sass-cache/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.github/
+.jekyll-cache/
+_site/
+aws_lambda/
+docker/
+.gitignore
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode/
 .vs/
-.idea
+.idea/
 _site/
 .sass-cache/
 .jekyll-cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,8 @@
-FROM ruby:2.7.1
-RUN mkdir /app
-WORKDIR /app
-COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock
+FROM jekyll/jekyll:3.8
 
-RUN bundle config set deployment true
-RUN bundle install --jobs=4
 
-COPY . /app
+WORKDIR /srv/jekyll
+COPY --chown=jekyll:jekyll . /srv/jekyll
 
 EXPOSE 3000
-
-ENTRYPOINT [ "bundle" ]
-
-CMD [ "exec", "jekyll", "serve", "--drafts", "-H", "0.0.0.0", "-P", "3000" ]
+CMD ["jekyll", "serve", "--drafts", "-H", "0.0.0.0", "-P", "3000" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,8 @@ WORKDIR /srv/jekyll
 COPY --chown=jekyll:jekyll . /srv/jekyll
 
 EXPOSE 3000
-CMD ["jekyll", "serve", "--drafts", "-H", "0.0.0.0", "-P", "3000" ]
+RUN bundle config set deployment true
+RUN bundle install --jobs=4
+
+
+CMD ["jekyll", "serve", "--drafts", "-H", "0.0.0.0", "-P", "3000", "--incremental" ]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Jeykll has functionality to include files, which this site makes extensive use o
 
 # Useful guides
 
+## Using Docker
+
+* Install [Docker](https://www.docker.com/get-started/) & start docker service.
+* Build image with jekyll run `docker-compose up --build` 
+  * You will need to re-run this command if any dependencies or docker configs change.
+* When editing in the future, run `docker-compose up`.
+* Site is hosted at http://0.0.0.0:3000
+
+Any changes made will be passed through to the container. 
+
 ## To add yourself to the people page
 
 * Create a branch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  jekyll-app:
+    build: .
+#    command: jekyell serve --drafts -H 0.0.0.0 -P 3000 --incremental
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/srv/jekyll
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3.9'
 services:
   jekyll-app:
     build: .
-#    command: jekyell serve --drafts -H 0.0.0.0 -P 3000 --incremental
     ports:
-      - 3000:3000
+      - "3000:3000"
     volumes:
       - .:/srv/jekyll
-
+      - /srv/jekyll/.idea/
+      - /srv/jekyll/.vscode/

--- a/docker/bundle.Dockerfile
+++ b/docker/bundle.Dockerfile
@@ -1,6 +1,0 @@
-FROM ruby:2.7.1
-RUN mkdir /app
-WORKDIR /app
-COPY Gemfile /app/Gemfile
-
-ENTRYPOINT [ "bundle" ]


### PR DESCRIPTION
Fixed Dockerfile, will run Jekyll and expose the site at `localhost:3000`. 
Fixes #113
Few things to do/investigate before merging:
- [x] Restore caching dependency installation
- [x] Possibility of hot-swapping updated files within container 
- [x] Add `.dockerignore` to reduce image/container size

## Notes for reviewer
- Added a guide to README for using docker/docker-compose.
- Removed `bundle.Dockerfile` as it shouldn't be used anymore.
- Commands for docker are:
  - `docker-compose up --build` to create the initial image & run
  - `docker-compose up` once built, only requires re-building when dependency or docker change.
- `.:/srv/jekyll` will pass through all folders & files in the current directory from the host system to the container, meaning incremental development. Caveat is none-jekyll files will also be copied over and watched by Jekyll.
- Site is hosted at http://0.0.0.0:3000 
