### PR TITLE
Gitignore for bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site/
 .jekyll-metadata
 .bundle/
 vendor/
+bin/


### PR DESCRIPTION
As part of the fix to get my website to build I had to do bundle binstub jekyll to put the Jekyll gem into a bin folder. This just ignores that in case anyone has to do the same.